### PR TITLE
Add encryption roundtrip tests

### DIFF
--- a/rust-enc-ui/Cargo.lock
+++ b/rust-enc-ui/Cargo.lock
@@ -2481,6 +2481,7 @@ dependencies = [
  "egui",
  "getrandom 0.3.3",
  "rfd",
+ "tempfile",
  "thiserror 2.0.14",
  "zeroize",
 ]

--- a/rust-enc-ui/Cargo.toml
+++ b/rust-enc-ui/Cargo.toml
@@ -13,3 +13,6 @@ getrandom = "0.3.3"
 rfd = "0.15.4"
 thiserror = "2.0.14"
 zeroize = "1.8.1"
+
+[dev-dependencies]
+tempfile = "3.10"

--- a/rust-enc-ui/src/lib.rs
+++ b/rust-enc-ui/src/lib.rs
@@ -1,0 +1,98 @@
+use aes_gcm::{
+    Aes256Gcm, KeyInit,
+    aead::{Aead, Key},
+};
+use anyhow::{Context, Result, anyhow};
+use argon2::Argon2;
+use getrandom::fill;
+use std::{fs, io::Write, path::PathBuf};
+use zeroize::Zeroize;
+
+const MAGIC: &[u8; 4] = b"RENC";
+const VERSION: u8 = 1;
+
+pub fn run_encrypt(input: Option<PathBuf>, output: Option<PathBuf>, password: &str) -> Result<()> {
+    let in_path = input.context("No input file selected")?;
+    let out_path = output.context("No output file selected")?;
+    let mut plaintext =
+        fs::read(&in_path).with_context(|| format!("Reading {}", in_path.display()))?;
+
+    // Derive key
+    let mut salt = [0u8; 16];
+    fill(&mut salt).map_err(|e| anyhow!("OS RNG failed for salt: {e}"))?;
+    let mut key = derive_key(password, &salt)?;
+
+    // AEAD
+    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(&key));
+    let mut nonce = [0u8; 12];
+    fill(&mut nonce).map_err(|e| anyhow!("OS RNG failed for nonce: {e}"))?;
+
+    let ciphertext = cipher
+        .encrypt((&nonce).into(), plaintext.as_ref())
+        .map_err(|_| anyhow!("Encryption failed"))?;
+
+    // Write: MAGIC|VERSION|SALT|NONCE|CIPHERTEXT
+    let mut out = Vec::with_capacity(4 + 1 + 16 + 12 + ciphertext.len());
+    out.extend_from_slice(MAGIC);
+    out.push(VERSION);
+    out.extend_from_slice(&salt);
+    out.extend_from_slice(&nonce);
+    out.extend_from_slice(&ciphertext);
+
+    let mut f =
+        fs::File::create(&out_path).with_context(|| format!("Creating {}", out_path.display()))?;
+    f.write_all(&out)?;
+    f.flush()?;
+
+    // Wipe sensitive material
+    plaintext.zeroize();
+    key.zeroize();
+
+    Ok(())
+}
+
+pub fn run_decrypt(input: Option<PathBuf>, output: Option<PathBuf>, password: &str) -> Result<()> {
+    let in_path = input.context("No input file selected")?;
+    let out_path = output.context("No output file selected")?;
+    let data = fs::read(&in_path).with_context(|| format!("Reading {}", in_path.display()))?;
+
+    // Parse header
+    if data.len() < 4 + 1 + 16 + 12 {
+        anyhow::bail!("File too short");
+    }
+    if &data[0..4] != MAGIC {
+        anyhow::bail!("Bad magic");
+    }
+    if data[4] != VERSION {
+        anyhow::bail!("Unsupported version");
+    }
+
+    let salt = &data[5..21];
+    let nonce = &data[21..33];
+    let ciphertext = &data[33..];
+
+    let mut key = derive_key(password, salt)?;
+    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(&key));
+
+    let mut plaintext = cipher
+        .decrypt(nonce.into(), ciphertext)
+        .map_err(|_| anyhow!("Decryption failed (wrong password or corrupted file)"))?;
+
+    fs::write(&out_path, &plaintext).with_context(|| format!("Writing {}", out_path.display()))?;
+
+    plaintext.zeroize();
+    key.zeroize();
+
+    Ok(())
+}
+
+fn derive_key(password: &str, salt: &[u8]) -> Result<[u8; 32]> {
+    let argon = Argon2::default();
+    let mut key = [0u8; 32];
+
+    argon
+        .hash_password_into(password.as_bytes(), salt, &mut key)
+        .map_err(|_| anyhow!("Key derivation failed"))?;
+
+    Ok(key)
+}

--- a/rust-enc-ui/src/main.rs
+++ b/rust-enc-ui/src/main.rs
@@ -1,14 +1,8 @@
-use std::{fs, io::Write, path::PathBuf};
-use anyhow::{anyhow, Context, Result};
-use eframe::{egui, NativeOptions};
+use anyhow::anyhow;
+use eframe::{NativeOptions, egui};
+use rust_enc_ui::{run_decrypt, run_encrypt};
+use std::path::PathBuf;
 use zeroize::Zeroize;
-
-use aes_gcm::{aead::{Aead, Key}, Aes256Gcm, KeyInit};
-use argon2::Argon2;
-use getrandom::fill;
-
-const MAGIC: &[u8; 4] = b"RENC";
-const VERSION: u8 = 1;
 
 fn main() -> eframe::Result<()> {
     let options = NativeOptions::default();
@@ -73,7 +67,14 @@ impl eframe::App for App {
 
             ui.separator();
 
-            if ui.button(if self.mode_encrypt { "Encrypt" } else { "Decrypt" }).clicked() {
+            if ui
+                .button(if self.mode_encrypt {
+                    "Encrypt"
+                } else {
+                    "Decrypt"
+                })
+                .clicked()
+            {
                 self.status.clear();
                 let res = if self.mode_encrypt {
                     if self.password != self.confirm_password {
@@ -109,92 +110,4 @@ impl eframe::App for App {
             }
         });
     }
-}
-
-fn run_encrypt(input: Option<PathBuf>, output: Option<PathBuf>, password: &str) -> Result<()> {
-    let in_path = input.context("No input file selected")?;
-    let out_path = output.context("No output file selected")?;
-    let mut plaintext = fs::read(&in_path)
-        .with_context(|| format!("Reading {}", in_path.display()))?;
-
-    // Derive key
-    let mut salt = [0u8; 16];
-    fill(&mut salt).map_err(|e| anyhow!("OS RNG failed for salt: {e}"))?;
-    let mut key = derive_key(password, &salt)?;
-
-    // AEAD
-    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(&key));
-    let mut nonce = [0u8; 12];
-    fill(&mut nonce).map_err(|e| anyhow!("OS RNG failed for nonce: {e}"))?;
-
-    let ciphertext = cipher
-        .encrypt((&nonce).into(), plaintext.as_ref())
-        .map_err(|_| anyhow!("Encryption failed"))?;
-
-    // Write: MAGIC|VERSION|SALT|NONCE|CIPHERTEXT
-    let mut out = Vec::with_capacity(4 + 1 + 16 + 12 + ciphertext.len());
-    out.extend_from_slice(MAGIC);
-    out.push(VERSION);
-    out.extend_from_slice(&salt);
-    out.extend_from_slice(&nonce);
-    out.extend_from_slice(&ciphertext);
-
-    let mut f = fs::File::create(&out_path)
-        .with_context(|| format!("Creating {}", out_path.display()))?;
-    f.write_all(&out)?;
-    f.flush()?;
-
-    // Wipe sensitive material from memory before returning
-    plaintext.zeroize();
-    key.zeroize();
-
-    Ok(())
-}
-
-fn run_decrypt(input: Option<PathBuf>, output: Option<PathBuf>, password: &str) -> Result<()> {
-    let in_path = input.context("No input file selected")?;
-    let out_path = output.context("No output file selected")?;
-    let data = fs::read(&in_path).with_context(|| format!("Reading {}", in_path.display()))?;
-
-    // Parse header
-    if data.len() < 4 + 1 + 16 + 12 {
-        anyhow::bail!("File too short");
-    }
-    if &data[0..4] != MAGIC {
-        anyhow::bail!("Bad magic");
-    }
-    if data[4] != VERSION {
-        anyhow::bail!("Unsupported version");
-    }
-
-    let salt = &data[5..21];
-    let nonce = &data[21..33];
-    let ciphertext = &data[33..];
-
-    let mut key = derive_key(password, salt)?;
-    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(&key));
-
-    let mut plaintext = cipher
-        .decrypt(nonce.into(), ciphertext)
-        .map_err(|_| anyhow!("Decryption failed (wrong password or corrupted file)"))?;
-
-    fs::write(&out_path, &plaintext)
-        .with_context(|| format!("Writing {}", out_path.display()))?;
-
-    plaintext.zeroize();
-    key.zeroize();
-
-    Ok(())
-}
-
-fn derive_key(password: &str, salt: &[u8]) -> Result<[u8; 32]> {
-    // Tunable Argon2id params (defaults OK to start; consider raising memory for production)
-    let argon = Argon2::default();
-    let mut key = [0u8; 32];
-
-    argon
-        .hash_password_into(password.as_bytes(), salt, &mut key)
-        .map_err(|_| anyhow!("Key derivation failed"))?;
-
-    Ok(key)
 }

--- a/rust-enc-ui/tests/encryption_roundtrip.rs
+++ b/rust-enc-ui/tests/encryption_roundtrip.rs
@@ -1,0 +1,33 @@
+use rust_enc_ui::{run_decrypt, run_encrypt};
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn encrypt_decrypt_roundtrip() -> anyhow::Result<()> {
+    let dir = tempdir()?;
+    let input = dir.path().join("plain.txt");
+    let encrypted = dir.path().join("cipher.bin");
+    let output = dir.path().join("decrypted.txt");
+    let data = b"secret message";
+    fs::write(&input, data)?;
+
+    run_encrypt(Some(input.clone()), Some(encrypted.clone()), "pw")?;
+    run_decrypt(Some(encrypted), Some(output.clone()), "pw")?;
+
+    let decrypted = fs::read(output)?;
+    assert_eq!(decrypted, data);
+    Ok(())
+}
+
+#[test]
+fn decrypt_with_wrong_password_fails() -> anyhow::Result<()> {
+    let dir = tempdir()?;
+    let input = dir.path().join("plain.txt");
+    let encrypted = dir.path().join("cipher.bin");
+    fs::write(&input, b"top secret")?;
+
+    run_encrypt(Some(input.clone()), Some(encrypted.clone()), "correct")?;
+    let result = run_decrypt(Some(encrypted), Some(dir.path().join("out.txt")), "wrong");
+    assert!(result.is_err());
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Expose `run_encrypt` and `run_decrypt` via new library module for reuse
- Cover encryption/decryption roundtrip and wrong password error with integration tests
- Add `tempfile` dev-dependency for test file handling

## Testing
- `cargo test --target-dir /tmp/target`


------
https://chatgpt.com/codex/tasks/task_e_689aa6a0224083338de1138c1046d829